### PR TITLE
Improve Application Versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *.dylib
 codex-svalinn
 svalinn
-OPATH/
+.ignore/
 
 # Test binary, build with `go test -c`
 *.test

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -2,12 +2,13 @@ FROM golang:alpine as builder
 MAINTAINER Jack Murdock <jack_murdock@comcast.com>
 
 WORKDIR /go/src/github.com/xmidt-org/svalinn
+ARG VERSION=undefined
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh
 
 COPY . .
-RUN GO111MODULE=on go build -o svalinn_linux_amd64
+RUN GO111MODULE=on go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$VERSION" -o svalinn_linux_amd64
 
 FROM alpine
 

--- a/deploy/Dockerfile.local
+++ b/deploy/Dockerfile.local
@@ -2,12 +2,13 @@ FROM golang:alpine as builder
 MAINTAINER Jack Murdock <jack_murdock@comcast.com>
 
 WORKDIR /go/src/github.com/xmidt-org/svalinn
+ARG VERSION=undefined
 
 RUN apk add --update git curl
 
 COPY . .
 
-RUN go build -o svalinn_linux_amd64
+RUN go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$VERSION" -o svalinn_linux_amd64
 
 FROM alpine
 

--- a/deploy/packaging/svalinn.spec
+++ b/deploy/packaging/svalinn.spec
@@ -23,7 +23,7 @@ The shield to protect our users from incoming events for the codex project.
 aka. The receiver of data from XMiDT Caduceus
 
 %build
-GO111MODULE=on go build -o $RPM_SOURCE_DIR/%{name} %{_topdir}/..
+GO111MODULE=on go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=%{_version}" -o $RPM_SOURCE_DIR/%{name} %{_topdir}/..
 
 %install
 echo rm -rf %{buildroot}

--- a/main.go
+++ b/main.go
@@ -22,11 +22,13 @@ import (
 	"crypto/sha1"
 	"fmt"
 	"github.com/xmidt-org/codex-db/cassandra"
+	"io"
 	olog "log"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"runtime"
 	"sync"
 	"time"
 
@@ -63,7 +65,12 @@ import (
 const (
 	applicationName, apiBase = "svalinn", "/api/v1"
 	DEFAULT_KEY_ID           = "current"
-	applicationVersion       = "0.12.0"
+)
+
+var (
+	GitCommit = "undefined"
+	Version   = "undefined"
+	BuildTime = "undefined"
 )
 
 type SvalinnConfig struct {
@@ -251,10 +258,19 @@ func printVersion(f *pflag.FlagSet, arguments []string) (error, bool) {
 	}
 
 	if *printVer {
-		fmt.Println(applicationVersion)
+		printVersionInfo(os.Stdout)
 		return nil, true
 	}
 	return nil, false
+}
+
+func printVersionInfo(writer io.Writer) {
+	fmt.Fprintf(writer, "%s:\n", applicationName)
+	fmt.Fprintf(writer, "  version: \t%s\n", Version)
+	fmt.Fprintf(writer, "  go version: \t%s\n", runtime.Version())
+	fmt.Fprintf(writer, "  built time: \t%s\n", BuildTime)
+	fmt.Fprintf(writer, "  git commit: \t%s\n", GitCommit)
+	fmt.Fprintf(writer, "  os/arch: \t%s/%s\n", runtime.GOOS, runtime.GOARCH)
 }
 
 func exitIfError(logger log.Logger, err error) {


### PR DESCRIPTION
This will allow for better bug reports and information the binary running. 
For example if you build a docker image with `make local-docker` you can get the version with the command `docker run --rm xmidt/svalinn:local -v`.
```
svalinn:
  version:      0.12.0+local
  go version:   go1.12.1
  built time:   2019-10-08 22:24:14
  git commit:   2b26b52
  os/arch:      linux/amd64
```