### PR TITLE
Security Release v0.14.4 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - https://github.com/xmidt-org/svalinn/issues/155
   - https://github.com/xmidt-org/svalinn/issues/154
   - https://github.com/xmidt-org/svalinn/issues/153
+- Upgrade wrp go from v2 to v3 [#166](https://github.com/xmidt-org/svalinn/pull/166)
 
 ## [v0.14.3]
 - bump dependencies [#152](https://github.com/xmidt-org/svalinn/pull/152)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v0.14.4]
+- Fix security vulns
+  - https://github.com/xmidt-org/svalinn/issues/155
+  - https://github.com/xmidt-org/svalinn/issues/154
+  - https://github.com/xmidt-org/svalinn/issues/153
+
 ## [v0.14.3]
 - bump dependencies [#152](https://github.com/xmidt-org/svalinn/pull/152)
 - Migrate to github actions, normalize analysis tools, Dockerfiles and Makefiles. [#140](https://github.com/xmidt-org/svalinn/pull/140)
@@ -151,7 +157,8 @@ Bug Fix Caduceus config loading
 - Initial creation
 - Bumped codex version, modified code to match changes
 
-[Unreleased]: https://github.com/xmidt-org/svalinn/compare/v0.14.3...HEAD
+[Unreleased]: https://github.com/xmidt-org/svalinn/compare/v0.14.4...HEAD
+[v0.14.3]: https://github.com/xmidt-org/svalinn/compare/v0.14.3...v0.14.4
 [v0.14.3]: https://github.com/xmidt-org/svalinn/compare/v0.14.2...v0.14.3
 [v0.14.2]: https://github.com/xmidt-org/svalinn/compare/v0.14.1...v0.14.2
 [v0.14.1]: https://github.com/xmidt-org/svalinn/compare/v0.14.0...v0.14.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - https://github.com/xmidt-org/svalinn/issues/153
 - Upgrade wrp go from v2 to v3 [#166](https://github.com/xmidt-org/svalinn/pull/166)
 
+
 ## [v0.14.3]
 - bump dependencies [#152](https://github.com/xmidt-org/svalinn/pull/152)
 - Migrate to github actions, normalize analysis tools, Dockerfiles and Makefiles. [#140](https://github.com/xmidt-org/svalinn/pull/140)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,7 +158,7 @@ Bug Fix Caduceus config loading
 - Bumped codex version, modified code to match changes
 
 [Unreleased]: https://github.com/xmidt-org/svalinn/compare/v0.14.4...HEAD
-[v0.14.3]: https://github.com/xmidt-org/svalinn/compare/v0.14.3...v0.14.4
+[v0.14.4]: https://github.com/xmidt-org/svalinn/compare/v0.14.3...v0.14.4
 [v0.14.3]: https://github.com/xmidt-org/svalinn/compare/v0.14.2...v0.14.3
 [v0.14.2]: https://github.com/xmidt-org/svalinn/compare/v0.14.1...v0.14.2
 [v0.14.1]: https://github.com/xmidt-org/svalinn/compare/v0.14.0...v0.14.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - https://github.com/xmidt-org/svalinn/issues/153
 - Upgrade wrp go from v2 to v3 [#166](https://github.com/xmidt-org/svalinn/pull/166)
 
-
 ## [v0.14.3]
 - bump dependencies [#152](https://github.com/xmidt-org/svalinn/pull/152)
 - Migrate to github actions, normalize analysis tools, Dockerfiles and Makefiles. [#140](https://github.com/xmidt-org/svalinn/pull/140)


### PR DESCRIPTION
What's included:

- Fix security vulns
  - https://github.com/xmidt-org/svalinn/issues/155
  - https://github.com/xmidt-org/svalinn/issues/154
  - https://github.com/xmidt-org/svalinn/issues/153
- Upgrade wrp go from v2 to v3 [#166](https://github.com/xmidt-org/svalinn/pull/166)
